### PR TITLE
Update oradbaas_oraclient.json

### DIFF
--- a/terraform/oracle/cam-ora/oradbsc/oradbaas_oraclient.json
+++ b/terraform/oracle/cam-ora/oradbsc/oradbaas_oraclient.json
@@ -224,8 +224,8 @@
             "hidden": false,
             "required": false,
             "secured": false,
-            "description": "Oracle dbname",
-            "default": "${templates.oradbaas13c2cfb6.output.dbserver_user_data}"
+            "description": "Oracle Database name",
+            "default": "${templates.oradbaas13c2cfb6.output.dbname}"
           },
           {
             "name": "oradb_connect",


### PR DESCRIPTION
Correct reference to Oracle database name so it is correctly displayed after service deployment.
Dependent on changes in oradbaas where dbname is defined as hidden output parameter.