### PR TITLE
Maintain compaitibility with schematics by restricting versions

### DIFF
--- a/terraform/jupyterlab-ibmcloud/versions.tf
+++ b/terraform/jupyterlab-ibmcloud/versions.tf
@@ -14,8 +14,8 @@
 ################################################################
 
 terraform {
-  required_version = ">= 0.11.14"
+  required_version = "0.11.14"
   required_providers {
-    ibm = "~>= 0.20.0"
+    ibm = "0.20.0"
   }
 }

--- a/terraform/lamp-stack-ibmcloud/versions.tf
+++ b/terraform/lamp-stack-ibmcloud/versions.tf
@@ -1,7 +1,7 @@
 
 terraform {
-  required_version = ">= 0.11.14"
+  required_version = "0.11.14"
   required_providers {
-    ibm = "~>= 0.20.0"
+    ibm = "0.20.0"
   }
 }

--- a/terraform/mean-stack-ibmcloud/versions.tf
+++ b/terraform/mean-stack-ibmcloud/versions.tf
@@ -14,8 +14,8 @@
 ################################################################
 
 terraform {
-  required_version = ">= 0.11.14"
+  required_version = "0.11.14"
   required_providers {
-    ibm = "~>= 0.20.0"
+    ibm = "0.20.0"
   }
 }

--- a/terraform/modules/simple_vm/versions.tf
+++ b/terraform/modules/simple_vm/versions.tf
@@ -14,8 +14,8 @@
 ################################################################
 
 terraform {
-  required_version = ">= 0.11.14"
+  required_version = "0.11.14"
   required_providers {
-    ibm = "~>= 0.20.0"
+    ibm = "0.20.0"
   }
 }


### PR DESCRIPTION
IBM Cloud Schematics is not at terraform version .12, hence restricting compatibility. 