### PR TITLE
Check for servergroup index

### DIFF
--- a/terraform/powervc-openshift/vm1-Master.tf
+++ b/terraform/powervc-openshift/vm1-Master.tf
@@ -199,7 +199,7 @@ resource "openstack_compute_instance_v2" "vm1" {
   }
 
   scheduler_hints {
-    group = "${openstack_compute_servergroup_v2.vm1-servergroup-affinity[0].id}"
+    group = var.vm1_number > 1 ? openstack_compute_servergroup_v2.vm1-servergroup-affinity[0].id : ""
   }
 
   #Cloud-Init user-data

--- a/terraform/powervc-openshift/vm2-Infra.tf
+++ b/terraform/powervc-openshift/vm2-Infra.tf
@@ -167,7 +167,7 @@ resource "openstack_compute_instance_v2" "vm2" {
   }
 
   scheduler_hints {
-    group = "${openstack_compute_servergroup_v2.vm2-servergroup-affinity[0].id}"
+    group = var.vm2_number > 1 ? openstack_compute_servergroup_v2.vm2-servergroup-affinity[0].id : ""
   }
 
   #Cloud-Init user-data

--- a/terraform/powervc-openshift/vm3-Worker.tf
+++ b/terraform/powervc-openshift/vm3-Worker.tf
@@ -168,7 +168,7 @@ resource "openstack_compute_instance_v2" "vm3" {
   }
 
   scheduler_hints {
-    group = "${openstack_compute_servergroup_v2.vm3-servergroup-affinity[0].id}"
+    group = var.vm3_number > 1 ? openstack_compute_servergroup_v2.vm3-servergroup-affinity[0].id : ""
   }
 
   #Cloud-Init user-data


### PR DESCRIPTION
This is related to #16 where Terraform fails with latest versions. This issue is not seen with older version eg: v0.12.0.

This extra check will ensure that terraform plan/apply will work with the latest version as well.