### PR TITLE
Add Ansible PowerVC Example

### DIFF
--- a/ansible/powervc/.gitignore
+++ b/ansible/powervc/.gitignore
@@ -1,0 +1,4 @@
+venv
+*.env
+powervcrc
+*.crt

--- a/ansible/powervc/README.md
+++ b/ansible/powervc/README.md
@@ -1,0 +1,21 @@
+# Automating PowerVC using Ansible
+
+Example Ansible configuration and playbooks for PowerVC. These files complement
+the IBM Power Systems Blog Post [Automating PowerVC using Ansible][1].
+
+## Requirements
+
+The Ansible OpenStack [os_server][2] module is used to create and delete
+PowerVC VM instances. This requires:
+
+* openstacksdk >= 0.12.0
+
+This can be installed in the Ansible Python environment using pip:
+`pip install "openstacksdk>=0.12.0"`
+
+Authentication is handled by openstacksdk, which can be configured in many
+ways. See [Configuring OpenStack SDK Applications][3] for details.
+
+[1]: https://developer.ibm.com/components/ibm-power/tutorials/automating-powervc-using-ansible/
+[2]: https://docs.ansible.com/ansible/latest/modules/os_server_module.html
+[3]: https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html

--- a/ansible/powervc/ansible.cfg
+++ b/ansible/powervc/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = ./openstack.yml
+
+[inventory]
+enable_plugins = host_list, openstack

--- a/ansible/powervc/create_vm.yml
+++ b/ansible/powervc/create_vm.yml
@@ -1,0 +1,39 @@
+---
+- name: Create a PowerVC Virtual Machine
+  hosts: localhost
+  vars:
+    image_id: YOUR_IMAGE_ID      # e.g.: 8c94ff78-7dac-4a2d-85ea-57d6c0f7777e
+    flavor_id: YOUR_FLAVOR_ID    # e.g.: 0df6759b-c2b6-41b8-914b-ec3b1c4a715b
+    network_name: YOUR_NET_NAME  # e.g.: static_network
+  tasks:
+    - name: Create an SSH Key Pair
+      os_keypair:
+        state: present
+        name: ansible-ssh-key
+        public_key_file: "{{ ansible_env.HOME }}/.ssh/id_rsa.pub"
+
+    - name: Create a new VM instance
+      os_server:
+        state: present
+        name: my-new-vm
+        image: "{{ iamge_id }}"
+        flavor: "{{ flavor_id }}"
+        key_name: ansible-ssh-key
+        nics:
+          - net-name: "{{ network_name }}"
+        meta:
+          hostname: my-new-vm
+          group: ansible-vms
+      register: vm
+
+    - name: Print VM's public IP address
+      debug:
+        var: vm.openstack.public_v4
+
+    - name: Waits for SSH port 22 to open
+      wait_for:
+        host: "{{ vm.openstack.public_v4 }}"
+        port: 22
+
+    - name: Add VM host key to known hosts
+      shell: "ssh-keyscan -H {{ vm.openstack.public_v4 }} >> ~/.ssh/known_hosts"

--- a/ansible/powervc/list_flavors.yml
+++ b/ansible/powervc/list_flavors.yml
@@ -1,0 +1,14 @@
+---
+- name: List available PowerVC Flavors
+  hosts: localhost
+  tasks:
+    - name: Retrieve list of all public flavors
+      os_flavor_info:
+        vcpus: ">=4"   # Optional filters
+        ram: ">16000"  # See module docs for more options
+      register: result
+
+    - name: Print flavor list
+      debug:
+        msg: "{{ result | json_query('openstack_flavors[?is_public==`true`].
+              {name: name, id: id, ram: ram, vcpus: vcpus}') }}"

--- a/ansible/powervc/list_images.yml
+++ b/ansible/powervc/list_images.yml
@@ -1,0 +1,15 @@
+---
+- name: List available PowerVC Images
+  hosts: localhost
+  tasks:
+    - name: Retrieve list of all AIX images
+      os_image_info:
+        properties:
+          os_distro: aix  # remove this line to list all images
+      register: result
+
+    - name: Print image list
+      debug:
+        msg: "{{ result | json_query('openstack_image[*].
+              {name: name, id: id, os_distro: os_distro, status: status,
+              project: location.project.name}') }}"

--- a/ansible/powervc/list_networks.yml
+++ b/ansible/powervc/list_networks.yml
@@ -1,0 +1,11 @@
+---
+- name: List available PowerVC Networks
+  hosts: localhost
+  tasks:
+    - name: Retrieve list of all networks
+      os_networks_info:
+      register: result
+
+    - name: Print Network list
+      debug:
+        var: result.openstack_networks

--- a/ansible/powervc/openstack.yml
+++ b/ansible/powervc/openstack.yml
@@ -1,0 +1,3 @@
+plugin: openstack
+expand_hostvars: true
+fail_on_errors: true


### PR DESCRIPTION
Add example Ansible configuration and playbooks for PowerVC. These files
complement the IBM Power Systems Blog Post 'Automating PowerVC using
Ansible'.

https://developer.ibm.com/components/ibm-power/tutorials/automating-powervc-using-ansible/